### PR TITLE
Add encinitas-collector-go provisioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: ☁ Login to ECR
         uses: docker/login-action@v3
         with:
-          registry: 952729869933.dkr.ecr.eu-west-1.amazonaws.com
+          registry: 017128164736.dkr.ecr.eu-west-1.amazonaws.com
           username: ${{ secrets.AWS_ACCESS_KEY_ID }}
           password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: 📦 Build and push

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN apk update && apk add --no-cache \
 COPY .  $GOPATH/src/github.com/jcleira/encinitas-collector-go/
 WORKDIR $GOPATH/src/github.com/jcleira/encinitas-collector-go/
 
-RUN go build -mod=vendor -o /go/bin/encinitas-collector-go
 RUN CGO_ENABLED=0 GOOS=linux \
   go build -a -installsuffix cgo -mod=vendor \
   -o /go/bin/encinitas-collector-go .
@@ -18,7 +17,7 @@ RUN CGO_ENABLED=0 GOOS=linux \
 # Runner stage
 FROM scratch
 
-COPY --from=builder /go/bin/encinitas-collector-go /go/bin/encinitas-collector-g-
+COPY --from=builder /go/bin/encinitas-collector-go /go/bin/encinitas-collector-go
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo

--- a/ci/chart/templates/deployment.yaml
+++ b/ci/chart/templates/deployment.yaml
@@ -38,12 +38,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.service.port }}
+              containerPort: 3001
               protocol: TCP
-          livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12 }}
-          readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- with .Values.volumeMounts }}

--- a/ci/chart/values.yaml
+++ b/ci/chart/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: 952729869933.dkr.ecr.eu-west-1.amazonaws.com/sales-ai
+  repository: 017128164736.dkr.ecr.eu-west-1.amazonaws.com/encinitas-collector-go
   tag: latest
   pullPolicy: IfNotPresent
 
@@ -27,29 +27,12 @@ ingress:
       hosts:
         - sales-ai-pre.bysidecar.me
 env:
-- name: AWS_REGION
-  value: "eu-west-1"
-- name: OPENAI_KEY
-  valueFrom:
-    secretKeyRef:
-      name: openai
-      key: apikey
-- name: DB_HOST
-  value: "pre.c848y92oajny.eu-west-1.rds.amazonaws.com"
-- name: DB_PORT
-  value: "3306"
-- name: DB_NAME
-  value: "sales_ai"
-- name: DB_USER
-  valueFrom:
-    secretKeyRef:
-      name: pre-database
-      key: user
-- name: DB_PASS
-  valueFrom:
-    secretKeyRef:
-      name: pre-database
-      key: pass
+- name: REDIS_ADDR
+  value: ""
+- name: REDIS_PASS
+  value: ""
+- name: REDIS_DB
+  value: 0
 
 autoscaling:
   enabled: false

--- a/config/config.go
+++ b/config/config.go
@@ -7,7 +7,7 @@ type Config struct {
 
 // Redis is the struct that holds the configuration of the Redis connection
 type Redis struct {
-	Addr     string `envconfig:"REDIS_ADDR" default:"localhost:6379"`
-	Password string `envconfig:"REDIS_PASS" default:""`
-	DB       int    `envconfig:"REDIS_DB" default:"0"`
+	Addr string `envconfig:"REDIS_ADDR" default:"localhost:6379"`
+	Pass string `envconfig:"REDIS_PASS" default:""`
+	DB   int    `envconfig:"REDIS_DB" default:"0"`
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.8"
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: encinitas-collector-go
+    environment:
+      REDIS_ADDR: redis:6379
+      REDIS_PASS:
+      REDIS_DB:
+    image: 017128164736.dkr.ecr.eu-west-1.amazonaws.com/encinitas-collector-go:dev
+    networks:
+      - encinitas_collector_go
+    ports:
+      - "3001:3001"
+    restart: unless-stopped
+
+  redis:
+    image: redis:latest
+    container_name: encinitas-redis
+    networks:
+      - encinitas_collector_go
+    ports:
+      - "6379:6379"
+    restart: unless-stopped
+
+networks:
+  encinitas_collector_go:

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func main() {
 
 	redisClient := redis.NewClient(&redis.Options{
 		Addr:     config.Redis.Addr,
-		Password: config.Redis.Password,
+		Password: config.Redis.Pass,
 		DB:       config.Redis.DB,
 	})
 
@@ -58,7 +58,7 @@ func main() {
 				),
 			).Handle,
 		)
-		return router.Run(":3000")
+		return router.Run(":3001")
 	})
 
 	g.Go(func() error {


### PR DESCRIPTION
* Objective

This commit objective is about completing the resources to provision
the encinitas-collector-go so it can be deployed in a server.

* Why

At some point, we will have to provision and deploy the
encinitas-collector-go, so these resources are a requirement for that
purpose.

* How

This commit completes the resources to provision the
encinitas-collector-go
