### PR TITLE
Add GET Transactions repositories & endpoint

### DIFF
--- a/internal/app/solana/aggregates/transaction.go
+++ b/internal/app/solana/aggregates/transaction.go
@@ -21,3 +21,50 @@ type Transaction struct {
 	ErrorInfo   *string
 	ProcessedAt *time.Time
 }
+
+// TransactionDetail is the domain representation of a solana transaction detail.
+type TransactionDetail struct {
+	ProgramAddress string
+	UpdatedOn      time.Time
+	RPCTime        int64
+	SolanaTime     int64
+	TotalTime      int64
+}
+
+// TransactionDetailAggregated is the domain representation of a solana
+// transaction detail aggregated.
+type TransactionDetailAggregated struct {
+	ProgramAddress string
+	Percentage     float64
+}
+
+type TransactionMeta struct {
+	Error             *string  `json:"error"`
+	Fee               int      `json:"fee"`
+	PreBalances       []int64  `json:"pre_balances"`
+	PostBalances      []int64  `json:"post_balances"`
+	InnerInstructions []string `json:"inner_instructions"`
+	LogMessages       []string `json:"log_messages"`
+	PreTokenBalances  []string `json:"pre_token_balances"`
+	PostTokenBalances []string `json:"post_token_balances"`
+	Rewards           []string `json:"rewards"`
+}
+
+type TransactionData struct {
+	Header          Header        `json:"header"`
+	AccountKeys     []string      `json:"account_keys"`
+	RecentBlockhash string        `json:"recent_blockhash"`
+	Instructions    []Instruction `json:"instructions"`
+}
+
+type Header struct {
+	NumRequiredSignatures       int `json:"num_required_signatures"`
+	NumReadonlySignedAccounts   int `json:"num_readonly_signed_accounts"`
+	NumReadonlyUnsignedAccounts int `json:"num_readonly_unsigned_accounts"`
+}
+
+type Instruction struct {
+	ProgramIDIndex int    `json:"program_id_index"`
+	Accounts       []int  `json:"accounts"`
+	Data           string `json:"data"`
+}

--- a/internal/infra/http/metrics/handlers/transactions.go
+++ b/internal/infra/http/metrics/handlers/transactions.go
@@ -1,0 +1,60 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/jcleira/encinitas-collector-go/internal/app/solana/aggregates"
+)
+
+// transactionsRetriever  defines the methods needed to retrievettransactions.
+type transactionsRetriever interface {
+	GetTransactionDetailAggregated(context.Context) ([]aggregates.TransactionDetailAggregated, error)
+}
+
+// TransactionsRetrieverHandler defines the dependencies to retrieve transactions.
+type TransactionsRetrieverHandler struct {
+	transactionsRetriever
+}
+
+// NewTransactionsRetriever initializes a new TransactionsRetrieverHandler.
+func NewTransactionsRetriever(
+	transactionsRetriever transactionsRetriever) *TransactionsRetrieverHandler {
+	return &TransactionsRetrieverHandler{
+		transactionsRetriever: transactionsRetriever,
+	}
+}
+
+// Handle is the handler function to retrieve transactions
+func (ech *TransactionsRetrieverHandler) Handle(c *gin.Context) {
+	transactions, err := ech.transactionsRetriever.GetTransactionDetailAggregated(
+		c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	httpTransactionsResponse := struct {
+		Transactions []struct {
+			ProgramAddress string  `json:"program_address"`
+			Percentage     float64 `json:"percentage"`
+		} `json:"transactions"`
+	}{}
+
+	for _, transaction := range transactions {
+		httpTransactionsResponse.Transactions = append(
+			httpTransactionsResponse.Transactions,
+			struct {
+				ProgramAddress string  `json:"program_address"`
+				Percentage     float64 `json:"percentage"`
+			}{
+				ProgramAddress: transaction.ProgramAddress,
+				Percentage:     transaction.Percentage,
+			},
+		)
+	}
+
+	c.JSON(http.StatusOK, httpTransactionsResponse)
+}

--- a/internal/infra/repositories/solana/sql/transaction.go
+++ b/internal/infra/repositories/solana/sql/transaction.go
@@ -2,6 +2,7 @@ package sql
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"time"
 
@@ -17,6 +18,34 @@ SELECT * FROM encinitas_transactions WHERE processed_at is NULL LIMIT 1000;
 UPDATE encinitas_transactions
 SET processed_at = :processed_at
 WHERE signature = :signature;
+`
+
+	insertTransactionDetailQuery = `
+INSERT INTO encinitas_transaction_details
+(program_address, updated_on, rpc_time, solana_time, total_time)
+VALUES
+(:program_address, :updated_on, :rpc_time, :solana_time, :total_time);
+`
+
+	getTransactionDetailAggregated = `
+WITH total_time AS (
+  SELECT program_address, SUM(total_time) as total_time
+  FROM encinitas_transaction_details
+  GROUP BY program_address
+),
+total_sum AS (
+  SELECT
+    SUM(total_time) AS overall_total_time
+  FROM
+   total_time
+)
+
+SELECT
+  T.program_address,
+  (T.total_time / TS.overall_total_time::FLOAT) * 100 AS percentage
+FROM
+  total_time T,
+  total_sum TS;
 `
 )
 
@@ -49,56 +78,142 @@ func (r *Repository) UpdateTransactionProcessedAt(
 	return nil
 }
 
+// InsertTransactionDetail inserts a new transaction detail into the database.
+func (r *Repository) InsertTransactionDetail(ctx context.Context,
+	detail aggregates.TransactionDetail) error {
+	dbTransactionDetail := dbTransactionDetailFromAggregate(detail)
+
+	if _, err := sqlx.NamedExec(r.db, insertTransactionDetailQuery,
+		dbTransactionDetail); err != nil {
+		return fmt.Errorf("sqlx.NamedExec, err: %w", err)
+	}
+
+	return nil
+}
+
+func (r *Repository) GetTransactionDetailAggregated(
+	ctx context.Context) ([]aggregates.TransactionDetailAggregated, error) {
+	var dbTransactionDetailsAggregated dbTransactionDetailsAggregated
+	if err := r.db.SelectContext(ctx,
+		&dbTransactionDetailsAggregated, getTransactionDetailAggregated); err != nil {
+		return nil, fmt.Errorf("r.db.SelectContext, err: %w", err)
+	}
+
+	transactionDetailsAggregated := make([]aggregates.TransactionDetailAggregated,
+		len(dbTransactionDetailsAggregated))
+	for i, dbTransactionDetail := range dbTransactionDetailsAggregated {
+		transactionDetailsAggregated[i] = dbTransactionDetail.toAggregate()
+	}
+
+	return transactionDetailsAggregated, nil
+}
+
 type dbTransaction struct {
-	Slot            int64      `db:"slot"`
-	Signature       string     `db:"signature"`
-	IsVote          bool       `db:"is_vote"`
-	MessageType     int        `db:"message_type"`
-	LegacyMessage   string     `db:"legacy_message"`
-	V0LoadedMessage *string    `db:"v0_loaded_message"`
-	Signatures      string     `db:"signatures"`
-	MessageHash     []byte     `db:"message_hash"`
-	Meta            string     `db:"meta"`
-	WriteVersion    int64      `db:"write_version"`
-	UpdatedOn       time.Time  `db:"updated_on"`
-	TxnIndex        int64      `db:"txn_index"`
-	InsertedAt      time.Time  `db:"inserted_at"`
-	ProcessedAt     *time.Time `db:"processed_at,omitempty"`
-	ErrorInfo       *string    `db:"error_info,omitempty"`
+	Slot            int64          `db:"slot"`
+	Signature       string         `db:"signature"`
+	IsVote          bool           `db:"is_vote"`
+	MessageType     int            `db:"message_type"`
+	LegacyMessage   string         `db:"legacy_message"`
+	V0LoadedMessage sql.NullString `db:"v0_loaded_message"`
+	Signatures      string         `db:"signatures"`
+	MessageHash     []byte         `db:"message_hash"`
+	Meta            string         `db:"meta"`
+	WriteVersion    int64          `db:"write_version"`
+	UpdatedOn       time.Time      `db:"updated_on"`
+	TxnIndex        int64          `db:"txn_index"`
+	InsertedAt      time.Time      `db:"inserted_at"`
+	ProcessedAt     *time.Time     `db:"processed_at,omitempty"`
 }
 
 type dbTransactions []dbTransaction
 
 func (dbe dbTransaction) toAggregate() aggregates.Transaction {
 	return aggregates.Transaction{
-		Slot:         dbe.Slot,
-		Signature:    dbe.Signature,
-		IsVote:       dbe.IsVote,
-		MessageType:  dbe.MessageType,
-		Signatures:   dbe.Signatures,
-		MessageHash:  dbe.MessageHash,
-		Meta:         dbe.Meta,
-		WriteVersion: dbe.WriteVersion,
-		UpdatedOn:    dbe.UpdatedOn,
-		TxnIndex:     dbe.TxnIndex,
-		ErrorInfo:    dbe.ErrorInfo,
-		ProcessedAt:  dbe.ProcessedAt,
+		Slot:            dbe.Slot,
+		Signature:       dbe.Signature,
+		IsVote:          dbe.IsVote,
+		MessageType:     dbe.MessageType,
+		LegacyMessage:   dbe.LegacyMessage,
+		V0LoadedMessage: dbe.V0LoadedMessage.String,
+		Signatures:      dbe.Signatures,
+		MessageHash:     dbe.MessageHash,
+		Meta:            dbe.Meta,
+		WriteVersion:    dbe.WriteVersion,
+		UpdatedOn:       dbe.UpdatedOn,
+		TxnIndex:        dbe.TxnIndex,
+		ProcessedAt:     dbe.ProcessedAt,
 	}
 }
 
 func dbTransactionFromAggregate(e aggregates.Transaction) dbTransaction {
 	return dbTransaction{
-		Slot:         e.Slot,
-		Signature:    e.Signature,
-		IsVote:       e.IsVote,
-		MessageType:  e.MessageType,
+		Slot:          e.Slot,
+		Signature:     e.Signature,
+		IsVote:        e.IsVote,
+		MessageType:   e.MessageType,
+		LegacyMessage: e.LegacyMessage,
+		V0LoadedMessage: sql.NullString{
+			String: e.V0LoadedMessage,
+			Valid:  e.V0LoadedMessage != "",
+		},
 		Signatures:   e.Signatures,
 		MessageHash:  e.MessageHash,
 		Meta:         e.Meta,
 		WriteVersion: e.WriteVersion,
 		UpdatedOn:    e.UpdatedOn,
 		TxnIndex:     e.TxnIndex,
-		ErrorInfo:    e.ErrorInfo,
 		ProcessedAt:  e.ProcessedAt,
+	}
+}
+
+type dbTransactionDetail struct {
+	ProgramAddress string    `db:"program_address"`
+	UpdatedOn      time.Time `db:"updated_on"`
+	RPCTime        int64     `db:"rpc_time"`
+	SolanaTime     int64     `db:"solana_time"`
+	TotalTime      int64     `db:"total_time"`
+}
+
+type dbTransactionDetails []dbTransactionDetail
+
+func (dbe dbTransactionDetail) toAggregate() aggregates.TransactionDetail {
+	return aggregates.TransactionDetail{
+		ProgramAddress: dbe.ProgramAddress,
+		UpdatedOn:      dbe.UpdatedOn,
+		RPCTime:        dbe.RPCTime,
+		SolanaTime:     dbe.SolanaTime,
+		TotalTime:      dbe.TotalTime,
+	}
+}
+
+func dbTransactionDetailFromAggregate(e aggregates.TransactionDetail) dbTransactionDetail {
+	return dbTransactionDetail{
+		ProgramAddress: e.ProgramAddress,
+		UpdatedOn:      e.UpdatedOn,
+		RPCTime:        e.RPCTime,
+		SolanaTime:     e.SolanaTime,
+		TotalTime:      e.TotalTime,
+	}
+}
+
+type dbTransactionDetailAggregated struct {
+	ProgramAddress string  `db:"program_address"`
+	Percentage     float64 `db:"percentage"`
+}
+
+type dbTransactionDetailsAggregated []dbTransactionDetailAggregated
+
+func (dbe dbTransactionDetailAggregated) toAggregate() aggregates.TransactionDetailAggregated {
+	return aggregates.TransactionDetailAggregated{
+		ProgramAddress: dbe.ProgramAddress,
+		Percentage:     dbe.Percentage,
+	}
+}
+
+func dbTransactionDetailAggregatedFromAggregate(
+	e aggregates.TransactionDetailAggregated) dbTransactionDetailAggregated {
+	return dbTransactionDetailAggregated{
+		ProgramAddress: e.ProgramAddress,
+		Percentage:     e.Percentage,
 	}
 }

--- a/main.go
+++ b/main.go
@@ -95,6 +95,7 @@ func main() {
 			solanaRepositoriesRedis.New(redisClient),
 			agentRepositoriesRedis.New(redisClient),
 			metricsRepositoriesInflux.New(influx),
+			solanaRepositoriesSQL.New(sqlx),
 		)
 
 		logger.Info("starting ingester")
@@ -119,6 +120,12 @@ func main() {
 		router.GET("/metrics/query",
 			metricsHandlers.NewMetricsRetriever(
 				metricsRepositoriesInflux.New(influx),
+			).Handle,
+		)
+
+		router.GET("/transactions/query",
+			metricsHandlers.NewTransactionsRetriever(
+				solanaRepositoriesSQL.New(sqlx),
 			).Handle,
 		)
 


### PR DESCRIPTION
* Objective

This commit objective is about adding the GET transaction endpoint which would return all the transactions and their percentage in load terms overall.

* Why

This endpoint is meant to feed the Transactions Page in the encinitas-ui.

* How

This commit introduces a new Solana Postgres SQL method that performs the fetching of the transaction information and creates a Handler that uses that endpoint