### PR TITLE
Update docker-compose setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,43 +7,16 @@ services:
       dockerfile: Dockerfile
     container_name: encinitas-collector-go
     environment:
-      REDIS_ADDR: localhost:6379
-      REDIS_PASS:
-      REDIS_DB:
-      POSTGRES_HOST: 100.71.248.65
+      REDIS_ADDR: 100.116.116.76:6379
+      REDIS_PASS: ${REDIS_PASS}
+      REDIS_DB: 0
+      POSTGRES_HOST: 100.107.126.77
       POSTGRES_PORT: 5432
-      POSTGRES_USER: postgres
+      POSTGRES_USER: solana
       POSTGRES_PASS: ${POSTGRES_PASS}
       POSTGRES_DB: solana
-      INFLUXDB_URL: http://localhost:8086
+      INFLUXDB_URL: http://100.116.116.76:8086
       INFLUXDB_TOKEN: ${INFLUXDB_TOKEN}
     image: 017128164736.dkr.ecr.eu-west-1.amazonaws.com/encinitas-collector-go:dev
     network_mode: host
     restart: unless-stopped
-
-  redis:
-    image: redis:latest
-    container_name: encinitas-redis
-    ports:
-      - "6379:6379"
-    restart: unless-stopped
-
-  influxdb:
-    image: influxdb:2.0
-    container_name: encinitas-influxdb
-    volumes:
-      - influxdb-volume:/var/lib/influxdb2
-    environment:
-      DOCKER_INFLUXDB_INIT_MODE: setup
-      DOCKER_INFLUXDB_INIT_USERNAME: influxdb
-      DOCKER_INFLUXDB_INIT_PASSWORD: ${INFLUXDB_PASS}
-      DOCKER_INFLUXDB_INIT_ORG: encinitas
-      DOCKER_INFLUXDB_INIT_BUCKET: encinitas_metrics
-      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: ${INFLUXDB_TOKEN}
-    ports:
-      - "8086:8086"
-    restart: unless-stopped
-
-volumes:
-  influxdb-volume:
-


### PR DESCRIPTION
* Objective

This commit objective is about simplying the docker-compose setup to use the local resources that has been provisioned instead of local images.

* Why

In this phase for encinitas this is a better option because we want to process both locally and remotelly the same set of transactions, so they are available for development but also for the alpha. This is not a good practice but is just for the alpha.

* How

This commit removes the docker dependencies of influx and redis.