### PR TITLE
Get influx error from the error channel

### DIFF
--- a/internal/app/agent/services/event_collector.go
+++ b/internal/app/agent/services/event_collector.go
@@ -36,6 +36,9 @@ func (ec *EventCollector) Collect(ctx context.Context) {
 
 	for {
 		select {
+		case <-ctx.Done():
+			return
+
 		case event := <-eventChan:
 			// For the moment we are only interested in successful responses
 			// so we can ignore the rest.
@@ -115,9 +118,6 @@ func (ec *EventCollector) Collect(ctx context.Context) {
 
 		case err := <-errChan:
 			slog.Error("error in the agent events redis repository: ", err)
-
-		case <-ctx.Done():
-			return
 		}
 	}
 }

--- a/internal/infra/repositories/agent/redis/events.go
+++ b/internal/infra/repositories/agent/redis/events.go
@@ -26,6 +26,9 @@ func (r *Repository) SubscribeToEvents(
 		defer pubsub.Close()
 		for {
 			select {
+			case <-ctx.Done():
+				return
+
 			case event := <-redisChannel:
 				var redisEvent redisEvent
 				if err := json.Unmarshal([]byte(event.Payload), &redisEvent); err != nil {
@@ -34,9 +37,6 @@ func (r *Repository) SubscribeToEvents(
 				}
 
 				eventChannel <- redisEvent.toAggregate()
-
-			case <-ctx.Done():
-				return
 			}
 		}
 	}()

--- a/internal/infra/repositories/metrics/influx/repository.go
+++ b/internal/infra/repositories/metrics/influx/repository.go
@@ -1,26 +1,41 @@
 package influx
 
 import (
+	"log/slog"
+
 	influxdb "github.com/influxdata/influxdb-client-go/v2"
+	influxdbapi "github.com/influxdata/influxdb-client-go/v2/api"
 )
 
 const (
 	organization       = "encinitas"
-	transactionsBucket = "encinitas_metrics"
-	programsBucket     = "encinitas_program_metrics"
+	TransactionsBucket = "encinitas_metrics"
+	ProgramsBucket     = "encinitas_program_metrics"
 )
 
 // Repository define the dependencies needed to store events in InfluxDB.
 type Repository struct {
-	client       influxdb.Client
-	organization string
+	client         influxdb.Client
+	influxdbWriter influxdbapi.WriteAPI
+	organization   string
+	bucket         string
 }
 
 // New creates a new instance of the InfluxDB repository.
-func New(client influxdb.Client) *Repository {
+func New(client influxdb.Client, bucket string) *Repository {
+	influxdbWriter := client.WriteAPI(organization, bucket)
+	errorsCh := influxdbWriter.Errors()
+	go func() {
+		for err := range errorsCh {
+			slog.Error("error writing to InfluxDB: ", err)
+		}
+	}()
+
 	return &Repository{
-		client:       client,
-		organization: organization,
+		client:         client,
+		organization:   organization,
+		bucket:         bucket,
+		influxdbWriter: influxdbWriter,
 	}
 }
 

--- a/internal/infra/repositories/solana/redis/transactions.go
+++ b/internal/infra/repositories/solana/redis/transactions.go
@@ -27,6 +27,9 @@ func (r *Repository) SubscribeToTransactions(
 		defer pubsub.Close()
 		for {
 			select {
+			case <-ctx.Done():
+				return
+
 			case transaction := <-redisChannel:
 				var redisTransaction redisTransaction
 				if err := json.Unmarshal([]byte(transaction.Payload), &redisTransaction); err != nil {
@@ -35,9 +38,6 @@ func (r *Repository) SubscribeToTransactions(
 				}
 
 				transactionChannel <- redisTransaction.toAggregate()
-
-			case <-ctx.Done():
-				return
 			}
 		}
 	}()

--- a/main.go
+++ b/main.go
@@ -94,7 +94,8 @@ func main() {
 		ingester := metricsServices.NewIngester(
 			solanaRepositoriesRedis.New(redisClient),
 			agentRepositoriesRedis.New(redisClient),
-			metricsRepositoriesInflux.New(influx),
+			metricsRepositoriesInflux.New(influx, metricsRepositoriesInflux.TransactionsBucket),
+			metricsRepositoriesInflux.New(influx, metricsRepositoriesInflux.ProgramsBucket),
 			solanaRepositoriesSQL.New(sqlx),
 		)
 
@@ -119,13 +120,15 @@ func main() {
 
 		router.GET("/metrics/query",
 			metricsHandlers.NewMetricsRetriever(
-				metricsRepositoriesInflux.New(influx),
+				metricsRepositoriesInflux.New(
+					influx, metricsRepositoriesInflux.TransactionsBucket),
 			).Handle,
 		)
 
 		router.GET("/metrics/programs/query",
 			metricsHandlers.NewMetricsProgramRetrieverHandler(
-				metricsRepositoriesInflux.New(influx),
+				metricsRepositoriesInflux.New(
+					influx, metricsRepositoriesInflux.ProgramsBucket),
 			).Handle,
 		)
 


### PR DESCRIPTION
* Objective

This commit objective is about capturing the influx's errors on the writer by initializing their capture while initializing an influx's repository.

* Why

We are noticing that the influx write operations are not working properly, it's not writing anything on the database... this is an attempt to capture what's going on.

* How

This commit initializes a go routing to capture the influx error channel.