### PR TITLE
Use Telefrag for writing in influxdb

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,7 @@ func (p Postgres) URL() string {
 }
 
 type InfluxDB struct {
-	URL   string `envconfig:"INFLUXDB_URL" default:"http://localhost:8086"`
-	Token string `envconfig:"INFLUXDB_TOKEN" default:""`
+	URL         string `envconfig:"INFLUXDB_URL" default:"http://localhost:8086"`
+	TelegrafURL string `envconfig:"INFLUXDB_TELEGRAF_URL" default:"http://localhost:8087"`
+	Token       string `envconfig:"INFLUXDB_TOKEN" default:""`
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       POSTGRES_PASS: ${POSTGRES_PASS}
       POSTGRES_DB: solana
       INFLUXDB_URL: http://100.116.116.76:8086
+      INFLUXDB_TELEGRAF_URL: http://100.116.116.76:8087/metrics
       INFLUXDB_TOKEN: ${INFLUXDB_TOKEN}
     image: 017128164736.dkr.ecr.eu-west-1.amazonaws.com/encinitas-collector-go:dev
     network_mode: host

--- a/internal/infra/repositories/metrics/influx/repository.go
+++ b/internal/infra/repositories/metrics/influx/repository.go
@@ -1,10 +1,7 @@
 package influx
 
 import (
-	"log/slog"
-
 	influxdb "github.com/influxdata/influxdb-client-go/v2"
-	influxdbapi "github.com/influxdata/influxdb-client-go/v2/api"
 )
 
 const (
@@ -15,27 +12,19 @@ const (
 
 // Repository define the dependencies needed to store events in InfluxDB.
 type Repository struct {
-	client         influxdb.Client
-	influxdbWriter influxdbapi.WriteAPI
-	organization   string
-	bucket         string
+	client       influxdb.Client
+	telegrafURL  string
+	organization string
+	bucket       string
 }
 
 // New creates a new instance of the InfluxDB repository.
-func New(client influxdb.Client, bucket string) *Repository {
-	influxdbWriter := client.WriteAPI(organization, bucket)
-	errorsCh := influxdbWriter.Errors()
-	go func() {
-		for err := range errorsCh {
-			slog.Error("error writing to InfluxDB: ", err)
-		}
-	}()
-
+func New(client influxdb.Client, telegrafURL, bucket string) *Repository {
 	return &Repository{
-		client:         client,
-		organization:   organization,
-		bucket:         bucket,
-		influxdbWriter: influxdbWriter,
+		client:       client,
+		organization: organization,
+		bucket:       bucket,
+		telegrafURL:  telegrafURL,
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -94,8 +94,11 @@ func main() {
 		ingester := metricsServices.NewIngester(
 			solanaRepositoriesRedis.New(redisClient),
 			agentRepositoriesRedis.New(redisClient),
-			metricsRepositoriesInflux.New(influx, metricsRepositoriesInflux.TransactionsBucket),
-			metricsRepositoriesInflux.New(influx, metricsRepositoriesInflux.ProgramsBucket),
+			metricsRepositoriesInflux.New(
+				influx,
+				config.InfluxDB.TelegrafURL,
+				metricsRepositoriesInflux.TransactionsBucket,
+			),
 			solanaRepositoriesSQL.New(sqlx),
 		)
 
@@ -121,14 +124,20 @@ func main() {
 		router.GET("/metrics/query",
 			metricsHandlers.NewMetricsRetriever(
 				metricsRepositoriesInflux.New(
-					influx, metricsRepositoriesInflux.TransactionsBucket),
+					influx,
+					config.InfluxDB.TelegrafURL,
+					metricsRepositoriesInflux.TransactionsBucket,
+				),
 			).Handle,
 		)
 
 		router.GET("/metrics/programs/query",
 			metricsHandlers.NewMetricsProgramRetrieverHandler(
 				metricsRepositoriesInflux.New(
-					influx, metricsRepositoriesInflux.ProgramsBucket),
+					influx,
+					config.InfluxDB.TelegrafURL,
+					metricsRepositoriesInflux.ProgramsBucket,
+				),
 			).Handle,
 		)
 


### PR DESCRIPTION
* Objective

This commit objective is about changing the influx repository so it uses Telegraf instead of writing directly onto influxdb.

* Why

The main reason is: performance; it has been a nightmare to get influxdb to behave, likely because of the way that we are writing metrics, etc.

* How

This commit changes the influx repository to use the telegraf agent instead of writing directly to influxdb