### PR TITLE
Use Solana Transaction Time

### DIFF
--- a/internal/app/metrics/aggregates/metric.go
+++ b/internal/app/metrics/aggregates/metric.go
@@ -8,7 +8,6 @@ type TransactionMetric struct {
 	EventID    string
 	Signature  string
 	UpdatedOn  time.Time
-	RPCTime    int64
 	SolanaTime int64
 	Error      bool
 }
@@ -17,7 +16,6 @@ type TransactionMetric struct {
 type ProgramMetric struct {
 	ProgramAddress string
 	UpdatedOn      time.Time
-	RPCTime        int64
 	SolanaTime     int64
 }
 
@@ -25,9 +23,6 @@ type ProgramMetric struct {
 type Type string
 
 const (
-	// TypeRPCTime represents the type of metric for the RPC time.
-	TypeRPCTime Type = "rpc_time"
-
 	// TypeSolanaTime represents the type of metric for the Solana time.
 	TypeSolanaTime Type = "solana_time"
 )

--- a/internal/infra/http/metrics/handlers/metrics.go
+++ b/internal/infra/http/metrics/handlers/metrics.go
@@ -62,7 +62,6 @@ func (ech *MetricsRetrieverHandler) Handle(c *gin.Context) {
 
 	httpMetricsResponse := struct {
 		Performance struct {
-			RPC    [][]interface{} `json:"rpc"`
 			Solana [][]interface{} `json:"solana"`
 		} `json:"performance"`
 		Throughput [][]interface{} `json:"throughput"`
@@ -71,15 +70,9 @@ func (ech *MetricsRetrieverHandler) Handle(c *gin.Context) {
 	}{}
 
 	for _, metric := range performanceMetrics {
-		if metric.Type == aggregates.TypeRPCTime {
-			httpMetricsResponse.Performance.RPC = append(
-				httpMetricsResponse.Performance.RPC,
-				[]interface{}{metric.Time, metric.Value})
-		} else {
-			httpMetricsResponse.Performance.Solana = append(
-				httpMetricsResponse.Performance.Solana,
-				[]interface{}{metric.Time, metric.Value})
-		}
+		httpMetricsResponse.Performance.Solana = append(
+			httpMetricsResponse.Performance.Solana,
+			[]interface{}{metric.Time, metric.Value})
 	}
 
 	for _, metric := range througputMetrics {

--- a/internal/infra/http/metrics/handlers/metrics_program.go
+++ b/internal/infra/http/metrics/handlers/metrics_program.go
@@ -54,22 +54,15 @@ func (ech *MetricsProgramRetrieverHandler) Handle(c *gin.Context) {
 
 	httpMetricsResponse := struct {
 		Performance struct {
-			RPC    [][]interface{} `json:"rpc"`
 			Solana [][]interface{} `json:"solana"`
 		} `json:"performance"`
 		Throughput [][]interface{} `json:"throughput"`
 	}{}
 
 	for _, metric := range performanceMetrics {
-		if metric.Type == aggregates.TypeRPCTime {
-			httpMetricsResponse.Performance.RPC = append(
-				httpMetricsResponse.Performance.RPC,
-				[]interface{}{metric.Time, metric.Value})
-		} else {
-			httpMetricsResponse.Performance.Solana = append(
-				httpMetricsResponse.Performance.Solana,
-				[]interface{}{metric.Time, metric.Value})
-		}
+		httpMetricsResponse.Performance.Solana = append(
+			httpMetricsResponse.Performance.Solana,
+			[]interface{}{metric.Time, metric.Value})
 	}
 
 	for _, metric := range througputMetrics {

--- a/internal/infra/repositories/solana/sql/transaction.go
+++ b/internal/infra/repositories/solana/sql/transaction.go
@@ -14,6 +14,10 @@ const (
 	selectTransactionsByProcessedAt = `
 SELECT * FROM encinitas_transactions WHERE processed_at is NULL LIMIT 1000;
 `
+	selectBlockTimeByBlockHash = `
+SELECT updated_on FROM block WHERE blockhash=$1;
+`
+
 	updateTransactionProcessedAt = `
 UPDATE encinitas_transactions
 SET processed_at = :processed_at
@@ -48,6 +52,17 @@ FROM
   total_sum TS;
 `
 )
+
+func (r *Repository) GetBlockTimeByBlockHash(
+	ctx context.Context, blockHash string) (time.Time, error) {
+	var updatedOn time.Time
+	if err := r.db.GetContext(ctx, &updatedOn,
+		selectBlockTimeByBlockHash, sql.Named("block_hash", blockHash)); err != nil {
+		return time.Time{}, fmt.Errorf("r.db.GetContext, err: %w", err)
+	}
+
+	return updatedOn, nil
+}
 
 func (r *Repository) SelectTransactionsByProcessedAt(
 	ctx context.Context) ([]aggregates.Transaction, error) {


### PR DESCRIPTION
* Objective

This commit objective is about start only using Solana Transaciton time in encinitas metrics

* Why

To make the alpha version simpler not using fake stats.

* How

This commit uses the recent_block hash time to calculate the "Solana Time" and removes the RPC time from the results