### PR TITLE
Use cache for metrics endpoints

### DIFF
--- a/internal/infra/http/metrics/handlers/cache/cache.go
+++ b/internal/infra/http/metrics/handlers/cache/cache.go
@@ -1,0 +1,56 @@
+package cache
+
+import (
+	"sync"
+	"time"
+
+	"github.com/jcleira/encinitas-collector-go/internal/app/metrics/aggregates"
+)
+
+type MetricsCache struct {
+	LastUpdate  time.Time
+	Performance aggregates.PerformanceResults
+	Throughput  aggregates.ThroughputResults
+	Apdex       aggregates.ApdexResults
+	Errors      aggregates.ErrorResults
+	mu          sync.RWMutex // Ensure thread-safe access to the cache
+}
+
+// Global instance of the cache
+var metricsCache = MetricsCache{}
+
+// UpdateCache updates the cache with new data
+func UpdateCache(
+	performance aggregates.PerformanceResults,
+	throughput aggregates.ThroughputResults,
+	apdex aggregates.ApdexResults,
+	errors aggregates.ErrorResults) {
+	metricsCache.mu.Lock()
+	defer metricsCache.mu.Unlock()
+	metricsCache.Performance = performance
+	metricsCache.Throughput = throughput
+	metricsCache.Apdex = apdex
+	metricsCache.Errors = errors
+	metricsCache.LastUpdate = time.Now()
+}
+
+// GetCache returns the current cache
+func GetCache() (
+	aggregates.PerformanceResults,
+	aggregates.ThroughputResults,
+	aggregates.ApdexResults,
+	aggregates.ErrorResults,
+	bool) {
+	metricsCache.mu.RLock()
+	defer metricsCache.mu.RUnlock()
+	if time.Since(metricsCache.LastUpdate) > 10*time.Minute {
+		return aggregates.PerformanceResults{},
+			aggregates.ThroughputResults{},
+			aggregates.ApdexResults{},
+			aggregates.ErrorResults{}, false
+	}
+	return metricsCache.Performance,
+		metricsCache.Throughput,
+		metricsCache.Apdex,
+		metricsCache.Errors, true
+}

--- a/internal/infra/http/metrics/handlers/cacheprogram/cache_program.go
+++ b/internal/infra/http/metrics/handlers/cacheprogram/cache_program.go
@@ -1,0 +1,45 @@
+package cacheprogram
+
+import (
+	"sync"
+	"time"
+
+	"github.com/jcleira/encinitas-collector-go/internal/app/metrics/aggregates"
+)
+
+type CacheItem struct {
+	Performance aggregates.PerformanceResults
+	Throughput  aggregates.ThroughputResults
+	LastUpdated time.Time
+}
+
+type MetricsCache struct {
+	mu       sync.RWMutex
+	cache    map[string]CacheItem
+	lifetime time.Duration
+}
+
+func NewMetricsCache(lifetime time.Duration) *MetricsCache {
+	return &MetricsCache{
+		cache:    make(map[string]CacheItem),
+		lifetime: lifetime,
+	}
+}
+
+func (m *MetricsCache) Get(key string) (CacheItem, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	item, found := m.cache[key]
+	if !found || time.Since(item.LastUpdated) > m.lifetime {
+		return CacheItem{}, false
+	}
+	return item, true
+}
+
+func (m *MetricsCache) Set(key string, item CacheItem) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.cache[key] = item
+}


### PR DESCRIPTION
* Objectives

This commit objective is about using a cache for the metrics endpoints.

* Why

Hitting the db while doing request was awful in terms of performance putting the alpha version in jeopardy, so better to implement a 10 minute cache, that doesn't affect the results for the information

* How

This commit creates an in-memory cache for the alpha